### PR TITLE
Initial implementation for middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*~
+Thumbs.db
+node_modules/
+_site/
+*.log
+*.log.*
+*.pid
+*.seed
+*.js
+*.html

--- a/README.md
+++ b/README.md
@@ -1,0 +1,246 @@
+# connect-react-html-template
+
+This is a connect middleware that can be used to rapidly integrate React into your server. By supplying this middleware with your frontend React application component, it will output HTML wrapped in your app. It can also pass the `path` param along to your app to be used with routers like [react-router-component][].
+
+## Usage
+
+To use, simply connect the middleware to your connect/express server:
+
+```js
+import connect from 'connect';
+import MyReactApp from 'my-react-app';
+import ConnectReactHtmlTemplate from '@economist/connect-react-html-template';
+const app = connect()
+  .use(ConnectReactHtmlTemplate({
+    props: {
+      handler: MyReactApp,
+    }
+  }));
+app.listen(8080);
+```
+
+### options
+
+#### options.layout
+
+By default, it uses a React Layout component to compose the webpage. If you want to use your own layout component, simply specify one:
+
+```js
+import connect from 'connect';
+import MyReactApp from 'my-react-app';
+import MyReactHTMLLayout from 'my-react-html-layout';
+import ConnectReactHtmlTemplate from '@economist/connect-react-html-template';
+const app = connect()
+  .use(ConnectReactHtmlTemplate({
+    layout: MyReactHTMLLayout
+    props: {
+      myHtmlLayoutProps: 1,
+      otherHtmlLayoutProps: 'hello',
+      children: MyReactApp,
+    }
+  }));
+app.listen(8080);
+```
+
+#### options.doctype
+
+By default, the middleware will prefix `<!doctype html>` to any React layout (as react cannot do this by itself). If you want a different doctype, just specify one:
+
+```js
+import connect from 'connect';
+import MyReactApp from 'my-react-app';
+import ConnectReactHtmlTemplate from '@economist/connect-react-html-template';
+const app = connect()
+  .use(ConnectReactHtmlTemplate({
+    // Welcome to 2003!
+    doctype: '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">',
+    props: {
+      handler: MyReactApp,
+    }
+  }));
+app.listen(8080);
+```
+
+#### options.headers
+
+By default, it will automatically send headers of `content-type: text/html; charset=utf8` and `cache-control: public, max-age=3600`. If you don't like either of these, you can override them with the `headers` option. In fact, you can add any headers you want!
+
+```js
+import connect from 'connect';
+import MyReactApp from 'my-react-app';
+import ConnectReactHtmlTemplate from '@economist/connect-react-html-template';
+const app = connect()
+  .use(ConnectReactHtmlTemplate({
+    headers: {
+      'content-type': 'application/xml; charset=utf-8',
+      'cache-control': 'no-cache, must-revalidate',
+      'pragma': 'no-cache',
+      'x-served-by': 'tehnodez',
+    },
+    props: {
+      handler: MyReactApp,
+    }
+  }));
+app.listen(8080);
+```
+
+### Default Layout
+
+The default layout has a set of props that you can use to make useful stuff happen:
+
+#### Layout Handler
+
+The most important thing about the default layout is its handler. This is your frontend React app. Simply pass the class in via props, and the layout will handle instantiation:
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    handler: MyReactComponent,
+  }
+})
+```
+
+Passing in a Handler is useful, because when it is instantiated, it is passed all of
+the props that the layout was passed, including the `path` which is generated from
+the middleware.
+
+If you don't have a React class/function, but just have some JSX, use `children` to inject it:
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    children: <div><h1>Hello world!</h1></div>,
+  }
+})
+```
+
+If you pass `children` _and_ `handler`, then `handler` will receive the children prop, and the layout wont render any children - just the handler:
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    handler: MyReactComponent,
+    // Default Layout doesnt render this! Just gives it to `handler`.
+    children: <div><h1>Hello world!</h1></div>,
+  }
+})
+```
+
+#### props.title
+
+This will, surprise surprise, set the pages title:
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    title: 'This is my cool web site! Please sign my guest book',
+  }
+})
+```
+
+#### props.lang
+
+This sets the html lang attribute, for example `<html lang="en">`. It defaults to `'en'`, but if you really need to disable it: pass `false`.
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    lang: 'en',
+  }
+});
+
+// Disable lang prop:
+ConnectReactHtmlTemplate({
+  props: {
+    lang: false,
+  }
+})
+```
+
+#### props.manifest
+
+If you're using an HTML5 Manifest, specify the URL with `manifest`:
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    manifest: '/application.manifest',
+  }
+});
+```
+
+#### props.meta
+
+Want to make some meta tags? Props.meta to the rescue!
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    meta: [
+      { charSet: 'utf-8' },
+      { httpEquiv: 'status', content: '200' },
+      { name: 'description', content: 'Hello World' },
+    ]
+  }
+});
+```
+
+#### props.styles
+
+Got some sick styles to show off to your friends? props.styles!
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    styles: [
+      'http://my.style.css',
+      { id: 'styles', href: '/style.css', media: 'screen' },
+    ]
+  }
+});
+```
+
+#### props.inlineStyles
+
+Need some inline styles for that sweet critical path? use `inlineStyles`.
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    inlineStyles: [
+      'body{background:blue}',
+      { id: 'critical', media: 'print', children: 'foo' },
+      { title: 'wut', disabled: true, children: 'bar' },
+    ]
+  }
+});
+```
+
+#### props.links
+
+Need some custom `<link>` tags, e.g. making apple-touch-icons? `props.links` will do it.
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    links: [
+      { rel: 'icon', id: 'foo', href: 'favicon.ico' },
+    ]
+  }
+});
+```
+#### props.scripts
+
+React pages wouldn't be React pages without some JS - put some in there with `props.scripts`.
+
+```js
+ConnectReactHtmlTemplate({
+  props: {
+    scripts: [
+      '/script.js',
+      { id: 'scriptz', src: '/hackz.js', className: 'wowmuchleet' },
+      { defer: true, async: true, src: 'dont-care.js' },
+    ]
+  }
+});
+```

--- a/index.es6
+++ b/index.es6
@@ -1,0 +1,32 @@
+/* eslint-disable */
+import React from 'react';
+import DefaultLayout from './layout';
+import { parse as parseUrl } from 'url';
+import { renderToString } from 'react-dom/server';
+export default ({ headers = {}, doctype = '<!doctype html>', layout = DefaultLayout, props = {} } = {}) => {
+  return (request, response, next) => {
+    try {
+      response.setHeader('content-type', 'text/html; charset=utf-8');
+      response.setHeader('cache-control', 'public, max-age=3600');
+      for (const header in headers) {
+        response.setHeader(header.toLowerCase(), headers[header]);
+      }
+      response.write(doctype);
+      // Send another write, as node buffers up the body until two write operations
+      response.write('');
+      // JSX expects a captial when rendering a Constructor, but our option isn't;
+      const Layout = layout;
+      response.write(
+        renderToString(
+          <Layout
+            path={parseUrl(request.url).pathname}
+            {...props}
+          />
+        )
+      );
+      response.end();
+    } catch (error) {
+      return next(error);
+    }
+  };
+};

--- a/layout.es6
+++ b/layout.es6
@@ -1,0 +1,165 @@
+import React, { Component, PropTypes } from 'react';
+const cssMedaTypes = [
+  'all',
+  'aural',
+  'braille',
+  'handheld',
+  'print',
+  'projection',
+  'screen',
+  'tty',
+  'TV',
+];
+const globalAttributes = {
+  /* eslint-disable id-length */
+  id: PropTypes.string,
+  /* eslint-enable id-length */
+  accesskey: PropTypes.string,
+  class: PropTypes.string,
+  contenteditable: PropTypes.boolean,
+  contextmenu: PropTypes.string,
+  dir: PropTypes.string,
+  hidden: PropTypes.boolean,
+  lang: PropTypes.string,
+  style: PropTypes.string,
+  tabindex: PropTypes.string,
+  title: PropTypes.string,
+  translate: PropTypes.string,
+};
+export default class Layout extends Component {
+
+  static get propTypes() {
+    return {
+      path: PropTypes.string,
+      lang: PropTypes.oneOfType([ PropTypes.string, PropTypes.boolean ]).isRequired,
+      title: PropTypes.string,
+      manifest: PropTypes.string,
+      meta: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.shape({
+            ...globalAttributes,
+            charSet: PropTypes.string,
+          }),
+          PropTypes.shape({
+            ...globalAttributes,
+            httpEquiv: PropTypes.string,
+            content: PropTypes.string,
+          }),
+          PropTypes.shape({
+            name: PropTypes.string,
+            content: PropTypes.string,
+          }),
+        ])
+      ),
+      inlineStyles: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.shape({
+            ...globalAttributes,
+            type: PropTypes.string,
+            media: PropTypes.oneOf(cssMedaTypes),
+            scoped: PropTypes.boolean,
+            disabled: PropTypes.boolean,
+          }),
+        ])
+      ),
+      styles: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.shape({
+            ...globalAttributes,
+            type: PropTypes.string,
+            integrity: PropTypes.string,
+            href: PropTypes.string,
+            hreflang: PropTypes.string,
+            media: PropTypes.oneOf(cssMedaTypes),
+          }),
+        ])
+      ),
+      links: PropTypes.arrayOf(
+        PropTypes.shape({
+          ...globalAttributes,
+          type: PropTypes.string,
+          integrity: PropTypes.string,
+          href: PropTypes.string,
+          hreflang: PropTypes.string,
+          media: PropTypes.oneOf(cssMedaTypes),
+          rel: PropTypes.string,
+        })
+      ),
+      scripts: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.shape({
+            ...globalAttributes,
+            type: PropTypes.string,
+            text: PropTypes.string,
+            integrity: PropTypes.string,
+            src: PropTypes.string.isRequired,
+            defer: PropTypes.boolean,
+            async: PropTypes.boolean,
+          }),
+        ])
+      ),
+      children: PropTypes.node,
+      handler: PropTypes.func,
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      lang: 'en',
+    };
+  }
+
+  renderArrayOfElements(Element, array) {
+    return (array || []).map((children) => {
+      let props = children;
+      if (typeof props !== 'object') {
+        props = { children };
+      }
+      return (<Element {...props}/>);
+    });
+  }
+
+  render() {
+    const htmlProps = {};
+    if (this.props.lang) {
+      htmlProps.lang = this.props.lang;
+    }
+    if (this.props.manifest) {
+      htmlProps.manifest = this.props.manifest;
+    }
+    const head = [
+      ...(this.renderArrayOfElements('meta', this.props.meta)),
+      <title>{this.props.title}</title>,
+      ...(this.renderArrayOfElements('style', this.props.inlineStyles)),
+      ...(this.renderArrayOfElements('link', (this.props.styles || []).map((href) => {
+        let props = href;
+        if (typeof href === 'string') {
+          props = { href };
+        }
+        return { rel: 'stylesheet', ...props };
+      }))),
+      ...(this.renderArrayOfElements('link', this.props.links)),
+      ...(this.renderArrayOfElements('script', (this.props.scripts || []).map((src) => {
+        let props = src;
+        if (typeof src === 'string') {
+          props = { src };
+        }
+        return { defer: true, ...props };
+      }))),
+    ];
+    let children = this.props.children || null;
+    if (this.props.handler) {
+      children = <this.props.handler {...this.props}/>;
+    }
+    return (
+      <html {...htmlProps}>
+        <head>{head}</head>
+        <body>{children}</body>
+      </html>
+    );
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@economist/connect-react-html-template",
+  "version": "1.0.0",
+  "description": "Serving React HTML templates as Connect Middleware!",
+  "author": "The Economist (http://economist.com)",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/economist-components/connect-react-html-template.git"
+  },
+  "homepage": "https://github.com/economist-components/connect-react-html-template#readme",
+  "bugs": {
+    "url": "https://github.com/economist-components/connect-react-html-template/issues"
+  },
+  "main": "index.js",
+  "files": [
+    "*.js"
+  ],
+  "babel": {
+    "stage": 2,
+    "loose": "all",
+    "compact": false
+  },
+  "eslintConfig": {
+    "parser": "babel-eslint",
+    "extends": [
+      "strict",
+      "strict-react"
+    ]
+  },
+  "config": {
+    "lint_opts": "--ignore-path .gitignore --ext .es6",
+    "testbundle_opts": "-r react -r .:./index.es6 -r ./example.js:example ./test/index.js -o testbundle.js",
+    "ghpages_files": "*.html *.css *.js assets/"
+  },
+  "scripts": {
+    "lint": "eslint $npm_package_config_lint_opts .",
+    "prepublish": "babel . -d . -x .es6",
+    "prepublish:watch": "npm run prepublish -- -w",
+    "pretest": "npm run lint",
+    "test": "mocha --compilers es6:babel/register"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0"
+  },
+  "devDependencies": {
+    "babel": "^5.8.23",
+    "babel-eslint": "^4.1.3",
+    "chai": "^3.4.0",
+    "chai-http": "^1.0.0",
+    "chai-spies": "^0.7.1",
+    "connect": "^3.4.0",
+    "eslint": "^1.3.1",
+    "eslint-config-strict": "^6.0.1",
+    "eslint-config-strict-react": "^3.0.0",
+    "eslint-plugin-filenames": "^0.1.2",
+    "eslint-plugin-react": "^3.3.1",
+    "mocha": "^2.3.3",
+    "pre-commit": "^1.1.2",
+    "react-addons-test-utils": "^0.14.0",
+    "react-dom": "^0.14.0"
+  },
+  "pre-commit": [
+    "lint"
+  ],
+  "dependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
+  }
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,1 @@
+{"extends":["strict","strict/mocha"]}

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,0 +1,155 @@
+import middleware from '../';
+import Layout from '../layout';
+import connect from 'connect';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import chaiSpies from 'chai-spies';
+import server from 'react-dom/server';
+import React from 'react';
+const httpStatusOk = 200;
+chai.use(chaiHttp).use(chaiSpies).should();
+/* eslint-disable arrow-parens */
+
+describe('React HTML Template Middleware', () => {
+  const originalRenderToString = server.renderToString;
+  let app = null;
+  let request = null;
+  let response = null;
+  beforeEach(async () => {
+    app = connect().use(middleware());
+    server.renderToString = chai.spy(() => '');
+    request = chai.request(app);
+    response = await request.get('/').buffer();
+  });
+
+  afterEach(() => {
+    server.renderToString = originalRenderToString;
+  });
+
+  it('renders the default doctype', () => {
+    response.should.have.property('text', '<!doctype html>');
+  });
+
+  it('appends the result of renderToString to doctype', async () => {
+    server.renderToString = chai.spy(() => '<html>foobar</html>');
+    response = await request.get('/');
+    response.should.have.status(httpStatusOk);
+    response.should.have.property('text', '<!doctype html><html>foobar</html>');
+  });
+
+  it('renders a default content-type', () => {
+    response.should.have.header('content-type', 'text/html; charset=utf-8');
+  });
+
+  it('renders default caching headers', () => {
+    response.should.have.header('cache-control', 'public, max-age=3600');
+  });
+
+  describe('configured with custom headers', () => {
+    beforeEach(async () => {
+      app = connect().use(middleware({
+        headers: {
+          'content-type': 'application/xml',
+          'pragma': 'no-cache',
+          'foobar': 'blooblux',
+        },
+      }));
+      chai.spy.on(server, 'renderToString');
+      request = chai.request(app);
+      response = await request.get('/');
+    });
+
+    it('sends the additional headers in the response', () => {
+      response.should.have.header('pragma', 'no-cache');
+    });
+
+    it('overrides default headers', () => {
+      response.should.have.header('content-type', 'application/xml');
+    });
+
+    it('sends any header (even non-registered)', () => {
+      response.should.have.header('foobar', 'blooblux');
+    });
+
+  });
+
+  describe('configured with custom doctype', () => {
+    beforeEach(async () => {
+      app = connect().use(middleware({
+        doctype: '<!foobar>',
+      }));
+      request = chai.request(app);
+      response = await request.get('/');
+    });
+
+    it('renders the default doctype', () => {
+      response.should.have.property('text', '<!foobar>');
+    });
+
+    it('appends the result of renderToString to doctype', async () => {
+      server.renderToString = chai.spy(() => '<html>foobar</html>');
+      response = await request.get('/');
+      response.should.have.status(httpStatusOk);
+      response.should.have.property('text', '<!foobar><html>foobar</html>');
+    });
+
+  });
+
+  describe('configured with custom layout', () => {
+
+    beforeEach(async () => {
+      app = connect().use(middleware({
+        layout: chai.spy(() => (<html/>)),
+      }));
+      server.renderToString = server.renderToStaticMarkup;
+      request = chai.request(app);
+      response = await request.get('/').buffer();
+    });
+
+    it('renders the given layout', () => {
+      response.should.have.property('text', '<!doctype html><html></html>');
+    });
+
+    it('gives Layout component the pathname', async () => {
+      app = connect().use(middleware({
+        layout: chai.spy((props) => (<html>{props.path}</html>)),
+        props: {
+          foo: 'bar',
+          baz: 'bing',
+        },
+      }));
+      response = await chai.request(app).get('/foo/bar/baz').buffer();
+      response.should.have.property('text', '<!doctype html><html>/foo/bar/baz</html>');
+    });
+
+    it('gives Layout all props', async () => {
+      app = connect().use(middleware({
+        layout: chai.spy((props) => (<html>{JSON.stringify(props)}</html>)),
+        props: {
+          foo: 'bar',
+          baz: 'bing',
+        },
+      }));
+      response = await chai.request(app).get('/biz').buffer();
+      const html = server.renderToStaticMarkup(
+        <html>{JSON.stringify({ path: '/biz', foo: 'bar', baz: 'bing' })}</html>
+      );
+      response.should.have.property('text', `<!doctype html>${html}`);
+    });
+
+  });
+
+  describe('default Layout option', () => {
+
+    it('defaults to the included Layout component', () => {
+      server.renderToString.should.have.been.called.exactly(1);
+      /* eslint-disable no-underscore-dangle */
+      const spyFirstCallArgs = server.renderToString.__spy.calls[0];
+      /* eslint-enable no-underscore-dangle */
+      spyFirstCallArgs[0].should.have.property('type', Layout);
+      spyFirstCallArgs[0].should.have.deep.property('props.path', '/');
+    });
+
+  });
+
+});

--- a/test/layout.es6
+++ b/test/layout.es6
@@ -1,0 +1,266 @@
+import Layout from '../layout';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import chai from 'chai';
+import chaiSpies from 'chai-spies';
+chai.use(chaiSpies).should();
+/* eslint id-length: 0 */
+describe('Layout', () => {
+  it('is compatible with React.Component', () => {
+    Layout.should.be.a('function')
+      .and.respondTo('render');
+  });
+
+  it('renders a React element', () => {
+    React.isValidElement(<Layout title="" path="" />).should.equal(true);
+  });
+
+  describe('Rendering', () => {
+    const renderer = TestUtils.createRenderer();
+    it('renders a standard html structure', () => {
+      renderer.render(<Layout title="mypage"/>, {});
+      renderer.getRenderOutput().should.deep.equal(
+        <html lang="en">
+          <head>{[ <title>mypage</title> ]}</head>
+          <body>{null}</body>
+        </html>
+      );
+    });
+
+    it('will use the passed in `lang` prop', () => {
+      renderer.render(<Layout title="mypage" lang="fr"/>, {});
+      renderer.getRenderOutput().should.deep.equal(
+        <html lang="fr">
+          <head>{[ <title>mypage</title> ]}</head>
+          <body>{null}</body>
+        </html>
+      );
+    });
+
+    it('will not render `lang` if prop falsey', () => {
+      renderer.render(<Layout title="mypage" lang={false}/>, {});
+      renderer.getRenderOutput().should.deep.equal(
+        <html>
+          <head>{[ <title>mypage</title> ]}</head>
+          <body>{null}</body>
+        </html>
+      );
+    });
+
+    it('will use the passed in `manifest` prop', () => {
+      renderer.render(<Layout title="mypage" manifest="app.manifest"/>, {});
+      renderer.getRenderOutput().should.deep.equal(
+        <html lang="en" manifest="app.manifest">
+          <head>{[ <title>mypage</title> ]}</head>
+          <body>{null}</body>
+        </html>
+      );
+    });
+
+    describe('<head> children', () => {
+
+      it('renders <meta> tags based on `meta` prop', () => {
+        renderer.render((
+          <Layout
+            title="head-tests"
+            meta={[
+              { charSet: 'utf-8' },
+              { httpEquiv: 'status', content: '200' },
+              { name: 'description', content: 'Hello World' },
+            ]}
+          />
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>
+              <meta charSet="utf-8"/>
+              <meta httpEquiv="status" content="200"/>
+              <meta name="description" content="Hello World"/>
+              <title>head-tests</title>
+            </head>
+            <body>{null}</body>
+          </html>
+        );
+      });
+
+      it('renders <inlineStyles> tags based on `inlineStyles` prop', () => {
+        renderer.render((
+          <Layout
+            title="head-tests"
+            inlineStyles={[
+              'body{background:blue}',
+              { id: 'critical', media: 'print', children: 'foo' },
+              { title: 'wut', disabled: true, children: 'bar' },
+            ]}
+          />
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>
+              <title>head-tests</title>
+              <style>{'body{background:blue}'}</style>
+              <style id="critical" media="print">foo</style>
+              <style title="wut" disabled>bar</style>
+            </head>
+            <body>{null}</body>
+          </html>
+        );
+      });
+
+      it('renders <link rel=stylesheet> tags based on `styles` prop', () => {
+        renderer.render((
+          <Layout
+            title="head-tests"
+            styles={[
+              'http://my.style.css',
+              { id: 'styles', href: '/style.css', media: 'screen' },
+            ]}
+          />
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>
+              <title>head-tests</title>
+              <link href="http://my.style.css" rel="stylesheet"/>
+              <link
+                rel="stylesheet"
+                id="styles"
+                href="/style.css"
+                media="screen"
+              />
+            </head>
+            <body>{null}</body>
+          </html>
+        );
+      });
+
+      it('renders <link rel=stylesheet> tags based on `styles` prop', () => {
+        renderer.render((
+          <Layout
+            title="head-tests"
+            links={[
+              { rel: 'icon', id: 'foo', href: 'favicon.ico' },
+            ]}
+          />
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>
+              <title>head-tests</title>
+              <link rel="icon" id="foo" href="favicon.ico"/>
+            </head>
+            <body>{null}</body>
+          </html>
+        );
+      });
+
+      it('renders <script> tags based on `scripts` prop', () => {
+        renderer.render((
+          <Layout
+            title="head-tests"
+            scripts={[
+              '/script.js',
+              { id: 'scriptz', src: '/hackz.js', className: 'wowmuchleet' },
+              { defer: true, async: true, src: 'dont-care.js' },
+            ]}
+          />
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>
+              <title>head-tests</title>
+              <script defer src="/script.js"/>
+              <script
+                defer
+                id="scriptz"
+                src="/hackz.js"
+                className="wowmuchleet"
+              />
+              <script defer async src="dont-care.js"/>
+            </head>
+            <body>{null}</body>
+          </html>
+        );
+      });
+
+    });
+
+    describe('<body> children', () => {
+
+      it('renders with Handler, given handler property', () => {
+        const Handler = chai.spy();
+        renderer.render(<Layout title="body-tests" handler={Handler}/>, {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>{[ <title>body-tests</title> ]}</head>
+            <body><Handler handler={Handler} lang="en" title="body-tests"/></body>
+          </html>
+        );
+      });
+
+      it('passes props through to handler', () => {
+        const Handler = chai.spy();
+        renderer.render((
+          <Layout
+            title="body-tests"
+            handler={Handler}
+            scripts={[ 'foo.js' ]}
+          />
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head><title>body-tests</title><script defer src="foo.js"/></head>
+            <body>
+              <Handler
+                handler={Handler}
+                lang="en"
+                title="body-tests"
+                scripts={[ 'foo.js' ]}
+              />
+            </body>
+          </html>
+        );
+      });
+
+      it('renders children, given children property (and no handler)', () => {
+        renderer.render((
+          <Layout title="body-tests">
+            <div><h1>Hello!</h1></div>
+          </Layout>
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>{[ <title>body-tests</title> ]}</head>
+            <body><div><h1>Hello!</h1></div></body>
+          </html>
+        );
+      });
+
+      it('passes children to Handler, if Handler given', () => {
+        const Handler = chai.spy();
+        renderer.render((
+          <Layout title="body-tests" handler={Handler}>
+            <div><h1>Hello!</h1></div>
+          </Layout>
+        ), {});
+        renderer.getRenderOutput().should.deep.equal(
+          <html lang="en">
+            <head>{[ <title>body-tests</title> ]}</head>
+            <body>
+              <Handler
+                handler={Handler}
+                lang="en"
+                title="body-tests"
+              >
+                <div><h1>Hello!</h1></div>
+              </Handler>
+            </body>
+          </html>
+        );
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Readme should describe how this works. Idea is to drop [component-world-if-html](https://github.com/the-economist-editorial/component-world-if-html) and [component-win-html](https://github.com/the-economist-editorial/component-win-html) and have this one generalised version instead.

\+@danielmoll